### PR TITLE
[FEAT] Location 테이블 분리

### DIFF
--- a/src/main/java/com/example/demo/location/domain/Location.java
+++ b/src/main/java/com/example/demo/location/domain/Location.java
@@ -1,0 +1,20 @@
+package com.example.demo.location.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class Location {
+
+    private Long locationId;
+    private Double latitude;
+    private Double longitude;
+
+    public Location(Double latitude, Double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/com/example/demo/location/repository/LocationMapper.java
+++ b/src/main/java/com/example/demo/location/repository/LocationMapper.java
@@ -1,0 +1,15 @@
+package com.example.demo.location.repository;
+
+import com.example.demo.location.domain.Location;
+import org.apache.ibatis.annotations.*;
+
+@Mapper
+public interface LocationMapper {
+
+    @Select("SELECT * FROM location WHERE latitude = #{latitude} AND longitude = #{longitude}")
+    Location findByLatitudeAndLongitude(@Param("latitude") Double latitude, @Param("longitude") Double longitude);
+
+    @Insert("INSERT INTO location (latitude, longitude) VALUES (#{latitude}, #{longitude})")
+    @Options(useGeneratedKeys = true, keyProperty = "locationId")
+    void saveLocation(Location location);
+}

--- a/src/main/java/com/example/demo/scene/controller/SceneController.java
+++ b/src/main/java/com/example/demo/scene/controller/SceneController.java
@@ -5,6 +5,7 @@ import com.example.demo.scene.dto.SceneCreateRequest;
 import com.example.demo.scene.dto.SceneUpdateRequest;
 import com.example.demo.scene.dto.SceneUpdateVisibilityRequest;
 import com.example.demo.scene.service.SceneService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -14,34 +15,35 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/scenes")
-@Tag(name="Scene", description="scene 테이블")
+@Tag(name="Scene", description="Scene 테이블 관련 API")
 public class SceneController {
 
     private final SceneService sceneService;
 
-    // SCENE 생성
+    @Operation(summary = "Scene 생성", description = "사용자의 socialId, 위도, 경도를 받아 Scene을 생성")
     @PostMapping
     public ResponseEntity<Scene> createScene(@RequestBody SceneCreateRequest request) {
         Scene scene = sceneService.createScene(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(scene);
     }
 
-    // SCENE 수정 (테마 수정)
+    @Operation(summary = "Scene 수정 (테마 수정)", description = "URL에서 sceneId를 받고 수정할 테마 정보를 RequestBody에서 받아 Scene 테마 수정")
     @PutMapping("/{sceneId}/theme")
     public ResponseEntity<Scene> updateScene(@PathVariable Long sceneId, @RequestBody SceneUpdateRequest request) {
         Scene scene = sceneService.updateScene(sceneId, request);
         return ResponseEntity.ok(scene);
     }
 
+    @Operation(summary = "Scene (메시지) 공개 상태 수정", description = "URL에서 sceneId를 받고 수정할 공개 상태를 RequestBody에서 받아 Scene의 메시지 공개 여부를 수정")
     @PutMapping("/{sceneId}/visibility")
     public ResponseEntity<Scene> updateVisibility(
             @PathVariable Long sceneId,
             @RequestBody SceneUpdateVisibilityRequest request) {
         Scene updatedScene = sceneService.updateVisibility(sceneId, request);
-        return ResponseEntity.ok(updatedScene); // 200 OK로 수정된 Scene 반환
+        return ResponseEntity.ok(updatedScene);
     }
 
-    // SCENE 조회
+    @Operation(summary = "Scene 조회", description = "URL에서 sceneId를 받아 해당 Scene 정보를 조회")
     @GetMapping("/{sceneId}")
     public ResponseEntity<Scene> getScene(@PathVariable Long sceneId) {
         Scene scene = sceneService.getScene(sceneId);

--- a/src/main/java/com/example/demo/scene/controller/SceneController.java
+++ b/src/main/java/com/example/demo/scene/controller/SceneController.java
@@ -34,7 +34,7 @@ public class SceneController {
         return ResponseEntity.ok(scene);
     }
 
-    @Operation(summary = "Scene (메시지) 공개 상태 수정", description = "URL에서 sceneId를 받고 수정할 공개 상태를 RequestBody에서 받아 Scene의 메시지 공개 여부를 수정")
+    @Operation(summary = "Scene 메시지 공개 상태 수정", description = "URL에서 sceneId를 받고 수정할 메시지 공개 상태를 RequestBody에서 받아 Scene의 메시지 공개 여부를 수정")
     @PutMapping("/{sceneId}/visibility")
     public ResponseEntity<Scene> updateVisibility(
             @PathVariable Long sceneId,

--- a/src/main/java/com/example/demo/scene/controller/SceneController.java
+++ b/src/main/java/com/example/demo/scene/controller/SceneController.java
@@ -5,6 +5,7 @@ import com.example.demo.scene.dto.SceneCreateRequest;
 import com.example.demo.scene.dto.SceneUpdateRequest;
 import com.example.demo.scene.dto.SceneUpdateVisibilityRequest;
 import com.example.demo.scene.service.SceneService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/scenes")
+@Tag(name="Scene", description="scene 테이블")
 public class SceneController {
 
     private final SceneService sceneService;

--- a/src/main/java/com/example/demo/scene/domain/Scene.java
+++ b/src/main/java/com/example/demo/scene/domain/Scene.java
@@ -1,5 +1,6 @@
 package com.example.demo.scene.domain;
 
+import com.example.demo.location.domain.Location;
 import com.example.demo.user.domain.User;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
@@ -14,18 +15,16 @@ public class Scene {
     private Long sceneId;
     private User user;  // 연관 관계는 매핑 파일에서 처리
     private String theme;
-    private Double latitude;
-    private Double longitude;
+    private Location location;
 
     @JsonProperty("isVisible")
     private boolean isVisible = false;
 
-    public Scene(Long sceneId, User user, String theme, Double latitude, Double longitude, boolean isVisible) {
+    public Scene(Long sceneId, User user, String theme, Location location, boolean isVisible) {
         this.sceneId = sceneId;
         this.user = user;
         this.theme = theme;
-        this.latitude = latitude;
-        this.longitude = longitude;
+        this.location = location;
         this.isVisible = isVisible;
     }
 }

--- a/src/main/java/com/example/demo/scene/domain/Scene.java
+++ b/src/main/java/com/example/demo/scene/domain/Scene.java
@@ -13,18 +13,18 @@ import lombok.Setter;
 public class Scene {
 
     private Long sceneId;
-    private User user;  // 연관 관계는 매핑 파일에서 처리
+    private User user;
     private String theme;
     private Location location;
 
-    @JsonProperty("isVisible")
-    private boolean isVisible = false;
+    @JsonProperty("isMessageVisible")
+    private boolean isMessageVisible = false;
 
-    public Scene(Long sceneId, User user, String theme, Location location, boolean isVisible) {
+    public Scene(Long sceneId, User user, String theme, Location location, boolean isMessageVisible) {
         this.sceneId = sceneId;
         this.user = user;
         this.theme = theme;
         this.location = location;
-        this.isVisible = isVisible;
+        this.isMessageVisible = isMessageVisible;
     }
 }

--- a/src/main/java/com/example/demo/scene/dto/SceneDto.java
+++ b/src/main/java/com/example/demo/scene/dto/SceneDto.java
@@ -6,10 +6,9 @@ import lombok.Setter;
 @Getter
 @Setter
 public class SceneDto {
-//    private Long sceneId;
-//    private String socialId;
+
     private String theme;
     private Double latitude;
     private Double longitude;
-    private boolean isVisible;
+    private boolean isMessageVisible;
 }

--- a/src/main/java/com/example/demo/scene/dto/SceneUpdateVisibilityRequest.java
+++ b/src/main/java/com/example/demo/scene/dto/SceneUpdateVisibilityRequest.java
@@ -7,6 +7,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class SceneUpdateVisibilityRequest {
-    @JsonProperty("isVisible")
-    private boolean isVisible;
+    @JsonProperty("isMessageVisible")
+    private boolean isMessageVisible;
 }

--- a/src/main/java/com/example/demo/scene/repository/SceneMapper.java
+++ b/src/main/java/com/example/demo/scene/repository/SceneMapper.java
@@ -7,7 +7,7 @@ import org.apache.ibatis.annotations.*;
 public interface SceneMapper {
     // Scene 조회 - Location 테이블 조인 추가
     @Select("""
-        SELECT s.scene_id, s.social_id, s.theme, s.is_visible,
+        SELECT s.scene_id, s.social_id, s.theme, s.is_message_visible,
                l.location_id, l.latitude, l.longitude
         FROM scene s
         JOIN location l ON s.location_id = l.location_id
@@ -17,7 +17,7 @@ public interface SceneMapper {
             @Result(property = "sceneId", column = "scene_id"),
             @Result(property = "user.socialId", column = "social_id"),
             @Result(property = "theme", column = "theme"),
-            @Result(property = "isVisible", column = "is_visible"),
+            @Result(property = "isMessageVisible", column = "is_message_visible"),
             // Location 매핑 추가
             @Result(property = "location.locationId", column = "location_id"),
             @Result(property = "location.latitude", column = "latitude"),
@@ -26,8 +26,8 @@ public interface SceneMapper {
     Scene findBySceneId(Long sceneId);
 
     // Scene 생성 - Location 참조 추가
-    @Insert("INSERT INTO scene (social_id, location_id, theme, is_visible) " +
-            "VALUES (#{user.socialId}, #{location.locationId}, #{theme}, #{isVisible})")
+    @Insert("INSERT INTO scene (social_id, location_id, theme, is_message_visible) " +
+            "VALUES (#{user.socialId}, #{location.locationId}, #{theme}, #{isMessageVisible})")
     @Options(useGeneratedKeys = true, keyProperty = "sceneId")
     void saveScene(Scene scene);
 
@@ -40,7 +40,7 @@ public interface SceneMapper {
     @Update("""
         UPDATE scene
         SET theme = #{theme},
-            is_visible = #{isVisible}
+            is_message_visible = #{isMessageVisible}
         WHERE scene_id = #{sceneId}
     """)
     void updateScene(Scene scene);

--- a/src/main/java/com/example/demo/scene/repository/SceneMapper.java
+++ b/src/main/java/com/example/demo/scene/repository/SceneMapper.java
@@ -5,20 +5,43 @@ import org.apache.ibatis.annotations.*;
 
 @Mapper
 public interface SceneMapper {
-
-    @Select("SELECT scene_id, social_id, theme, latitude, longitude, is_visible " +
-            "FROM scene WHERE scene_id = #{sceneId}")
+    // Scene 조회 - Location 테이블 조인 추가
+    @Select("""
+        SELECT s.scene_id, s.social_id, s.theme, s.is_visible,
+               l.location_id, l.latitude, l.longitude
+        FROM scene s
+        JOIN location l ON s.location_id = l.location_id
+        WHERE s.scene_id = #{sceneId}
+    """)
+    @Results({
+            @Result(property = "sceneId", column = "scene_id"),
+            @Result(property = "user.socialId", column = "social_id"),
+            @Result(property = "theme", column = "theme"),
+            @Result(property = "isVisible", column = "is_visible"),
+            // Location 매핑 추가
+            @Result(property = "location.locationId", column = "location_id"),
+            @Result(property = "location.latitude", column = "latitude"),
+            @Result(property = "location.longitude", column = "longitude")
+    })
     Scene findBySceneId(Long sceneId);
 
-    @Insert("INSERT INTO scene (social_id, theme, latitude, longitude, is_visible) " +
-            "VALUES (#{user.socialId}, #{theme}, #{latitude}, #{longitude}, #{isVisible})")
-    @Options(useGeneratedKeys = true, keyProperty = "sceneId")  // sceneId를 자동으로 설정
+    // Scene 생성 - Location 참조 추가
+    @Insert("INSERT INTO scene (social_id, location_id, theme, is_visible) " +
+            "VALUES (#{user.socialId}, #{location.locationId}, #{theme}, #{isVisible})")
+    @Options(useGeneratedKeys = true, keyProperty = "sceneId")
     void saveScene(Scene scene);
 
+
+    // Scene 삭제
     @Delete("DELETE FROM scene WHERE scene_id = #{sceneId}")
     void deleteScene(Long sceneId);
 
-    @Update("UPDATE scene SET theme = #{theme}, latitude = #{latitude}, longitude = #{longitude}, " +
-            "is_visible = #{isVisible} WHERE scene_id = #{sceneId}")
+    // Scene 수정
+    @Update("""
+        UPDATE scene
+        SET theme = #{theme},
+            is_visible = #{isVisible}
+        WHERE scene_id = #{sceneId}
+    """)
     void updateScene(Scene scene);
 }

--- a/src/main/java/com/example/demo/scene/service/SceneService.java
+++ b/src/main/java/com/example/demo/scene/service/SceneService.java
@@ -38,7 +38,7 @@ public class SceneService {
         scene.setUser(user);
         scene.setTheme(request.getTheme());
         scene.setLocation(location);
-        scene.setVisible(false);
+        scene.setMessageVisible(false);
 
         // Scene 저장
         sceneMapper.saveScene(scene);
@@ -58,7 +58,7 @@ public class SceneService {
     @Transactional
     public Scene updateVisibility(Long sceneId, SceneUpdateVisibilityRequest request) {
         Scene scene = sceneMapper.findBySceneId(sceneId);
-        scene.setVisible(request.isVisible());
+        scene.setMessageVisible(request.isMessageVisible());
         sceneMapper.updateScene(scene);  // SceneMapper의 update 메서드 호출
         return scene;
     }

--- a/src/main/java/com/example/demo/scene/service/SceneService.java
+++ b/src/main/java/com/example/demo/scene/service/SceneService.java
@@ -1,5 +1,7 @@
 package com.example.demo.scene.service;
 
+import com.example.demo.location.domain.Location;
+import com.example.demo.location.repository.LocationMapper;
 import com.example.demo.scene.domain.Scene;
 import com.example.demo.scene.dto.SceneCreateRequest;
 import com.example.demo.scene.dto.SceneUpdateRequest;
@@ -15,53 +17,47 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SceneService {
 
-    private final SceneMapper sceneMapper;  // SceneMapper로 변경
-    private final UserMapper userMapper;  // UserMapper로 변경
-
+    private final SceneMapper sceneMapper;
+    private final UserMapper userMapper;
+    private final LocationMapper locationMapper;
     // SCENE 생성
     @Transactional
     public Scene createScene(SceneCreateRequest request) {
-        // User를 SocialId로 찾기
         User user = userMapper.findBySocialId(request.getSocialId());
         if (user == null) {
             throw new IllegalArgumentException("User not found");
         }
 
+        Location location = locationMapper.findByLatitudeAndLongitude(request.getLatitude(), request.getLongitude());
+        if (location == null) {
+            location = new Location(request.getLatitude(), request.getLongitude());
+            locationMapper.saveLocation(location);
+        }
+
         Scene scene = new Scene();
         scene.setUser(user);
         scene.setTheme(request.getTheme());
-        scene.setLatitude(request.getLatitude());
-        scene.setLongitude(request.getLongitude());
+        scene.setLocation(location);
         scene.setVisible(false);
 
         // Scene 저장
-        sceneMapper.saveScene(scene);  // SceneMapper의 insert 메서드 호출
+        sceneMapper.saveScene(scene);
         return scene;
     }
 
     // SCENE 수정
     @Transactional
     public Scene updateScene(Long sceneId, SceneUpdateRequest request) {
-        // Scene을 ID로 찾기
         Scene scene = sceneMapper.findBySceneId(sceneId);
-        if (scene == null) {
-            throw new IllegalArgumentException("Scene not found");
-        }
-
         scene.setTheme(request.getTheme());
-        sceneMapper.updateScene(scene);  // SceneMapper의 update 메서드 호출
+        sceneMapper.updateScene(scene);
         return scene;
     }
 
     // SCENE 공개 설정 수정
     @Transactional
     public Scene updateVisibility(Long sceneId, SceneUpdateVisibilityRequest request) {
-        // Scene을 ID로 찾기
         Scene scene = sceneMapper.findBySceneId(sceneId);
-        if (scene == null) {
-            throw new IllegalArgumentException("Scene not found");
-        }
-
         scene.setVisible(request.isVisible());
         sceneMapper.updateScene(scene);  // SceneMapper의 update 메서드 호출
         return scene;
@@ -70,11 +66,6 @@ public class SceneService {
     // SCENE 조회
     @Transactional(readOnly = true)
     public Scene getScene(Long sceneId) {
-        // Scene을 ID로 찾기
-        Scene scene = sceneMapper.findBySceneId(sceneId);
-        if (scene == null) {
-            throw new IllegalArgumentException("Scene not found");
-        }
-        return scene;
+        return sceneMapper.findBySceneId(sceneId);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=demo


### PR DESCRIPTION
## 유형
- [x] 기능 추가

## 설명
- Location 테이블 분리 및 Scene 조인 처리  
- API 수정 및 테스트 완료  
- Scene의 `isVisible` 필드를 `isMessageVisible`로 필드명 수정  

## 테스트
1. `ALTER TABLE` 쿼리로 Scene 테이블의 필드명 수정  
2. Swagger에서 수정된 필드가 API 응답에 정상적으로 반영되는지 확인  
3. Scene 생성/수정/조회 시 정상 응답인지 확인


## 이슈
closes #11 
