### PR TITLE
[FEAT] crypto

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ repositories {
 
 dependencies {
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
-//    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -36,6 +35,9 @@ dependencies {
     // Flyway
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
+
+    //암호화
+    implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/example/demo/message/controller/MessageController.java
+++ b/src/main/java/com/example/demo/message/controller/MessageController.java
@@ -31,7 +31,7 @@ public class MessageController {
     // 특정 sceneId의 모든 메시지 조회 (쿼리 파라미터 방식)
     @GetMapping
     @Operation(summary = "메세지 조회", description = "특정 scene의 message를 조회")
-    public ResponseEntity<List<MessageResponse>> getMessagesBySceneId(@RequestParam Long scene) {
+    public ResponseEntity<List<MessageResponse>> getMessagesBySceneId(@RequestParam String scene) {
         List<MessageResponse> responses = messageService.getMessagesBySceneId(scene);
         return ResponseEntity.ok(responses);
     }

--- a/src/main/java/com/example/demo/message/dto/MessageDeleteRequest.java
+++ b/src/main/java/com/example/demo/message/dto/MessageDeleteRequest.java
@@ -6,6 +6,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class MessageDeleteRequest {
-    private Long sceneId;
+    private String sceneId;
     private Long messageId;
 }

--- a/src/main/java/com/example/demo/message/dto/MessageRequest.java
+++ b/src/main/java/com/example/demo/message/dto/MessageRequest.java
@@ -6,7 +6,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class MessageRequest {
-    private Long sceneId;
+    private String sceneId;
     private String nickname;
     private String content;
 }

--- a/src/main/java/com/example/demo/message/service/MessageService.java
+++ b/src/main/java/com/example/demo/message/service/MessageService.java
@@ -8,6 +8,7 @@ import com.example.demo.message.repository.MessageMapper;
 import com.example.demo.scene.domain.Scene;
 import com.example.demo.scene.repository.SceneMapper;
 import com.example.demo.user.service.KakaoAuthService;
+import com.example.demo.utils.AESUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,10 +26,14 @@ public class MessageService {
     private final MessageMapper messageMapper;
     private final SceneMapper sceneMapper;
     private final KakaoAuthService kakaoAuthService;
+    private final AESUtil aesUtil;
 
     // 특정 sceneId의 메시지 리스트 조회
     @Transactional
-    public List<MessageResponse> getMessagesBySceneId(Long sceneId) {
+    public List<MessageResponse> getMessagesBySceneId(String encryptedSceneId) {
+        // 암호화된 sceneId를 복호화
+        Long sceneId = aesUtil.decryptSceneId(encryptedSceneId);  // 복호화된 sceneId 사용
+
         // Scene을 찾고, 해당 sceneId에 맞는 메시지들을 조회
         List<Message> messages = messageMapper.findMessagesBySceneId(sceneId);
         if (messages == null || messages.isEmpty()) {
@@ -48,7 +53,11 @@ public class MessageService {
     // 메시지 생성
     @Transactional
     public Message createMessage(MessageRequest request) {
-        Scene scene = sceneMapper.findBySceneId(request.getSceneId());
+        // sceneId를 복호화
+        Long sceneId = aesUtil.decryptSceneId(request.getSceneId());  // 복호화된 sceneId 사용
+
+
+        Scene scene = sceneMapper.findBySceneId(sceneId);
         if (scene == null) {
             throw new IllegalArgumentException("Scene not found");
         }
@@ -71,18 +80,21 @@ public class MessageService {
         // 1. accessToken을 이용해 Kakao 사용자 정보 조회
         String socialId = kakaoAuthService.getUserInfo(accessToken).getKakao_account().getEmail();
 
-        // 2. sceneId에 해당하는 Scene 조회
-        Scene scene = sceneMapper.findBySceneId(request.getSceneId());
+        // 2. 암호화된 sceneId 복호화
+        Long sceneId = aesUtil.decryptSceneId(String.valueOf(request.getSceneId()));  // 복호화된 sceneId 사용
+
+        // 3. sceneId에 해당하는 Scene 조회
+        Scene scene = sceneMapper.findBySceneId(sceneId);
         if (scene == null) {
             throw new IllegalArgumentException("Scene not found");
         }
 
-        // 3. social_id 검증 (Scene의 소유자와 요청자가 같은지 확인)
+        // 4. social_id 검증 (Scene의 소유자와 요청자가 같은지 확인)
         if (!scene.getUser().getSocialId().equals(socialId)) {
             throw new IllegalArgumentException("Unauthorized: You are not the owner of this scene.");
         }
 
-        // 4. 메시지 삭제
+        // 5. 메시지 삭제
         messageMapper.deleteMessage(request.getMessageId());
     }
 }

--- a/src/main/java/com/example/demo/scene/controller/SceneController.java
+++ b/src/main/java/com/example/demo/scene/controller/SceneController.java
@@ -34,7 +34,7 @@ public class SceneController {
     @Operation(summary = "Scene 수정 (테마 수정)", description = "URL에서 sceneId를 받고 수정할 테마 정보를 RequestBody에서 받아 Scene 테마 수정")
     @PutMapping("/{encryptedSceneId}/theme")  // 암호화된 sceneId
     public ResponseEntity<Scene> updateScene(@PathVariable String encryptedSceneId, @RequestBody SceneUpdateRequest request) {
-        Long sceneId = decryptSceneId(encryptedSceneId);  // 암호화된 sceneId 복호화
+        Long sceneId = aesUtil.decryptSceneId(encryptedSceneId);  // 암호화된 sceneId 복호화
         Scene scene = sceneService.updateScene(sceneId, request);
         return ResponseEntity.ok(scene);
     }
@@ -44,7 +44,7 @@ public class SceneController {
     public ResponseEntity<Scene> updateVisibility(
             @PathVariable String encryptedSceneId,
             @RequestBody SceneUpdateVisibilityRequest request) {
-        Long sceneId = decryptSceneId(encryptedSceneId);  // 암호화된 sceneId 복호화
+        Long sceneId = aesUtil.decryptSceneId(encryptedSceneId);  // 암호화된 sceneId 복호화
         Scene updatedScene = sceneService.updateVisibility(sceneId, request);
         return ResponseEntity.ok(updatedScene);
     }
@@ -52,19 +52,9 @@ public class SceneController {
     @Operation(summary = "Scene 정보 조회", description = "URL에서 sceneId를 받아 해당 Scene 정보를 조회")
     @GetMapping("/{encryptedSceneId}")  // 암호화된 sceneId
     public ResponseEntity<Scene> getScene(@PathVariable String encryptedSceneId) {
-        Long sceneId = decryptSceneId(encryptedSceneId);  // 암호화된 sceneId 복호화
+        Long sceneId = aesUtil.decryptSceneId(encryptedSceneId);  // 암호화된 sceneId 복호화
         Scene scene = sceneService.getScene(sceneId);
         return ResponseEntity.ok(scene);
-    }
-
-    // 암호화된 sceneId를 복호화하는 메서드
-    private Long decryptSceneId(String encryptedSceneId) {
-        try {
-            String decryptedId = aesUtil.decrypt(encryptedSceneId);  // 암호화된 sceneId 복호화
-            return Long.parseLong(decryptedId);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("잘못된 접근입니다. 유효하지 않은 게시판 ID입니다.");
-        }
     }
 
     @Operation(summary = "AccessToken을 받아 암호화된 Scene ID 반환", description = "헤더에서 accessToken을 받아 사용자가 조회할 수 있는 Scene ID를 암호화하여 반환")

--- a/src/main/java/com/example/demo/scene/controller/SceneController.java
+++ b/src/main/java/com/example/demo/scene/controller/SceneController.java
@@ -5,6 +5,8 @@ import com.example.demo.scene.dto.SceneCreateRequest;
 import com.example.demo.scene.dto.SceneUpdateRequest;
 import com.example.demo.scene.dto.SceneUpdateVisibilityRequest;
 import com.example.demo.scene.service.SceneService;
+import com.example.demo.user.service.KakaoAuthService;
+import com.example.demo.utils.AESUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,8 @@ import org.springframework.web.bind.annotation.*;
 public class SceneController {
 
     private final SceneService sceneService;
+    private final AESUtil aesUtil;
+    private final KakaoAuthService kakaoAuthService;
 
     @Operation(summary = "Scene 생성", description = "사용자의 socialId와 theme를 받아 Scene을 생성")
     @PostMapping
@@ -28,26 +32,53 @@ public class SceneController {
     }
 
     @Operation(summary = "Scene 수정 (테마 수정)", description = "URL에서 sceneId를 받고 수정할 테마 정보를 RequestBody에서 받아 Scene 테마 수정")
-    @PutMapping("/{sceneId}/theme")
-    public ResponseEntity<Scene> updateScene(@PathVariable Long sceneId, @RequestBody SceneUpdateRequest request) {
+    @PutMapping("/{encryptedSceneId}/theme")  // 암호화된 sceneId
+    public ResponseEntity<Scene> updateScene(@PathVariable String encryptedSceneId, @RequestBody SceneUpdateRequest request) {
+        Long sceneId = decryptSceneId(encryptedSceneId);  // 암호화된 sceneId 복호화
         Scene scene = sceneService.updateScene(sceneId, request);
         return ResponseEntity.ok(scene);
     }
 
     @Operation(summary = "Scene 메시지 공개 상태 수정", description = "URL에서 sceneId를 받고 수정할 메시지 공개 상태를 RequestBody에서 받아 Scene의 메시지 공개 여부를 수정")
-    @PutMapping("/{sceneId}/visibility")
+    @PutMapping("/{encryptedSceneId}/visibility")  // 암호화된 sceneId
     public ResponseEntity<Scene> updateVisibility(
-            @PathVariable Long sceneId,
+            @PathVariable String encryptedSceneId,
             @RequestBody SceneUpdateVisibilityRequest request) {
+        Long sceneId = decryptSceneId(encryptedSceneId);  // 암호화된 sceneId 복호화
         Scene updatedScene = sceneService.updateVisibility(sceneId, request);
         return ResponseEntity.ok(updatedScene);
     }
 
-    @Operation(summary = "Scene 조회", description = "URL에서 sceneId를 받아 해당 Scene 정보를 조회")
-    @GetMapping("/{sceneId}")
-    public ResponseEntity<Scene> getScene(@PathVariable Long sceneId) {
+    @Operation(summary = "Scene 정보 조회", description = "URL에서 sceneId를 받아 해당 Scene 정보를 조회")
+    @GetMapping("/{encryptedSceneId}")  // 암호화된 sceneId
+    public ResponseEntity<Scene> getScene(@PathVariable String encryptedSceneId) {
+        Long sceneId = decryptSceneId(encryptedSceneId);  // 암호화된 sceneId 복호화
         Scene scene = sceneService.getScene(sceneId);
         return ResponseEntity.ok(scene);
+    }
+
+    // 암호화된 sceneId를 복호화하는 메서드
+    private Long decryptSceneId(String encryptedSceneId) {
+        try {
+            String decryptedId = aesUtil.decrypt(encryptedSceneId);  // 암호화된 sceneId 복호화
+            return Long.parseLong(decryptedId);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("잘못된 접근입니다. 유효하지 않은 게시판 ID입니다.");
+        }
+    }
+
+    @Operation(summary = "AccessToken을 받아 암호화된 Scene ID 반환", description = "헤더에서 accessToken을 받아 사용자가 조회할 수 있는 Scene ID를 암호화하여 반환")
+    @GetMapping()
+    public ResponseEntity<String> getEncryptedSceneId(@RequestHeader("access-token") String accessToken) {
+        String socialId = kakaoAuthService.getUserInfo(accessToken).getKakao_account().getEmail();
+
+        // socialId를 통해 해당 Scene 조회
+        Long sceneId = sceneService.getSceneIdBySocialId(socialId);
+
+        // sceneId 암호화
+        String encryptedSceneId = aesUtil.encrypt(String.valueOf(sceneId));
+
+        return ResponseEntity.ok(encryptedSceneId);
     }
 
 }

--- a/src/main/java/com/example/demo/scene/repository/SceneMapper.java
+++ b/src/main/java/com/example/demo/scene/repository/SceneMapper.java
@@ -38,4 +38,18 @@ public interface SceneMapper {
         WHERE scene_id = #{sceneId}
     """)
     void updateScene(Scene scene);
+
+    // Scene 조회 - socialId 기반으로 Scene 찾기
+    @Select("""
+        SELECT s.scene_id, s.social_id, s.theme, s.is_message_visible
+        FROM scene s
+        WHERE s.social_id = #{socialId}
+    """)
+    @Results({
+            @Result(property = "sceneId", column = "scene_id"),
+            @Result(property = "user.socialId", column = "social_id"),
+            @Result(property = "theme", column = "theme"),
+            @Result(property = "isMessageVisible", column = "is_message_visible"),
+    })
+    Scene findBySocialId(String socialId);
 }

--- a/src/main/java/com/example/demo/scene/service/SceneService.java
+++ b/src/main/java/com/example/demo/scene/service/SceneService.java
@@ -59,4 +59,14 @@ public class SceneService {
     public Scene getScene(Long sceneId) {
         return sceneMapper.findBySceneId(sceneId);
     }
+
+    // socialId로 Scene을 찾아서 sceneId 반환
+    public Long getSceneIdBySocialId(String socialId) {
+        Scene scene = sceneMapper.findBySocialId(socialId);  // socialId 기반으로 Scene 조회
+        if (scene != null) {
+            return scene.getSceneId();
+        } else {
+            throw new IllegalArgumentException("해당 socialId에 맞는 Scene을 찾을 수 없습니다.");
+        }
+    }
 }

--- a/src/main/java/com/example/demo/utils/AESUtil.java
+++ b/src/main/java/com/example/demo/utils/AESUtil.java
@@ -28,4 +28,14 @@ public class AESUtil {
         String decodedText = new String(Base64.getUrlDecoder().decode(encryptedText));
         return encryptor.decrypt(decodedText);
     }
+
+    // 암호화된 sceneId를 복호화하는 메서드
+    public Long decryptSceneId(String encryptedSceneId) {
+        try {
+            String decryptedId = decrypt(encryptedSceneId);  // 암호화된 sceneId 복호화
+            return Long.parseLong(decryptedId);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("잘못된 접근입니다. 유효하지 않은 게시판 ID입니다.");
+        }
+    }
 }

--- a/src/main/java/com/example/demo/utils/AESUtil.java
+++ b/src/main/java/com/example/demo/utils/AESUtil.java
@@ -1,0 +1,31 @@
+package com.example.demo.utils;
+
+import org.jasypt.util.text.AES256TextEncryptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+
+@Component
+public class AESUtil {
+    private final AES256TextEncryptor encryptor;
+
+    public AESUtil(@Value("${jasypt.encryptor.password}") String secretKey) {
+        this.encryptor = new AES256TextEncryptor();
+        this.encryptor.setPassword(secretKey);
+    }
+
+    // 암호화
+    public String encrypt(String plainText) {
+        String encryptedText = encryptor.encrypt(plainText);
+        // Base64 URL-safe 인코딩
+        return Base64.getUrlEncoder().encodeToString(encryptedText.getBytes());
+    }
+
+    // 복호화
+    public String decrypt(String encryptedText) {
+        // Base64 URL-safe 디코딩
+        String decodedText = new String(Base64.getUrlDecoder().decode(encryptedText));
+        return encryptor.decrypt(decodedText);
+    }
+}


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [x] 문서 수정

## 설명
- AES256 방식으로 sceneId를 양방향 암호화 처리해 URL 접근의 보안성을 높인다
- message, scene접근 api에서 통신에서는 암호화된 sceneId를 사용하고 server내에서는 복호화 과정을 거친 후 실제 sceneId 로 DB접근 합니다
- 암호화된 sceneId는 String, 실제 DB의 sceneId는 int입니다
- 암호화, 복호화에 필요한 키는 applicaiont.yml에서 따로 관리합니다

## 테스트
1.  swagger에서 scene생성
2. accessToken으로 생성된 scene의 암호화된 id 조회
3. 해당 id로 sceneId를 사용하는 타 api접근

## 이슈
closes #18 
