### PR TITLE
[FEAT] 중복 scene 방지

### DIFF
--- a/src/main/java/com/example/demo/scene/controller/SceneController.java
+++ b/src/main/java/com/example/demo/scene/controller/SceneController.java
@@ -4,6 +4,7 @@ import com.example.demo.common.dto.ApiResponse;
 import com.example.demo.scene.dto.SceneRequest;
 import com.example.demo.scene.dto.SceneResponse;
 import com.example.demo.scene.dto.SceneUpdateVisibilityRequest;
+import com.example.demo.scene.exception.DuplicateSceneException;
 import com.example.demo.scene.service.SceneService;
 import com.example.demo.user.service.KakaoAuthService;
 import com.example.demo.utils.AESUtil;
@@ -142,4 +143,10 @@ public class SceneController {
         return ResponseEntity.ok(encryptedSceneId);
     }
 
+    // DuplicateSceneException 처리
+    @ExceptionHandler(DuplicateSceneException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDuplicateSceneException(DuplicateSceneException e) {
+        ApiResponse<Void> errorResponse = ApiResponse.<Void>error(e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    }
 }

--- a/src/main/java/com/example/demo/scene/exception/DuplicateSceneException.java
+++ b/src/main/java/com/example/demo/scene/exception/DuplicateSceneException.java
@@ -1,0 +1,7 @@
+package com.example.demo.scene.exception;
+
+public class DuplicateSceneException extends RuntimeException {
+    public DuplicateSceneException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/demo/scene/service/SceneService.java
+++ b/src/main/java/com/example/demo/scene/service/SceneService.java
@@ -4,6 +4,7 @@ import com.example.demo.scene.domain.Scene;
 import com.example.demo.scene.dto.SceneRequest;
 import com.example.demo.scene.dto.SceneResponse;
 import com.example.demo.scene.dto.SceneUpdateVisibilityRequest;
+import com.example.demo.scene.exception.DuplicateSceneException;
 import com.example.demo.scene.repository.SceneMapper;
 import com.example.demo.user.domain.User;
 import com.example.demo.user.repository.UserMapper;
@@ -62,6 +63,12 @@ public class SceneService {
 
         String socialId = kakaoAccount.getEmail();
         log.info("Retrieved socialId from Kakao: {}", socialId);
+
+        Scene existingScene = sceneMapper.findBySocialId(socialId);
+        if (existingScene != null) {
+            log.error("Scene already exists for user with socialId: {}", socialId);
+            throw new DuplicateSceneException("이미 해당 사용자의 Scene이 존재합니다: " + socialId);
+        }
 
         // 사용자 정보 조회
         User user = userMapper.findBySocialId(socialId);


### PR DESCRIPTION
## 유형
- 버그 수정

## 설명
- userId 하나당 하나의 scene만 생성가능하게 합니다
- 중복 scene생성 시도 시, 409에러를 반환합니다

## 테스트
1. swagger에서 같은 accessToken으로 중복 scene생성 요청을 합니다
2. 최초 1회 요청 외 중복요청은 409 status와 함께 실패합니다

<img width="717" alt="image" src="https://github.com/user-attachments/assets/515b3ec0-8dfe-4840-9c34-39aac0366143" />
![image](https://github.com/user-attachments/assets/0d1df728-4a83-436f-a942-54580162ede7)

- 로컬 테스트에서 최초 1회 scene생성 성공
- 2회부터 409오류를 반환하며 db에 적용되지 않음을 확인했습니다

## 이슈
close #45 
