### PR TITLE
[FIX] scene 조회 시 user info 추가 제공 

### DIFF
--- a/src/main/java/com/example/demo/scene/dto/SceneResponse.java
+++ b/src/main/java/com/example/demo/scene/dto/SceneResponse.java
@@ -16,4 +16,7 @@ public class SceneResponse {
     @JsonProperty("isMessageVisible")
     private boolean isMessageVisible;
     private String ownerSocialId;
+
+    private String ownerNickname;
+    private String ownerProfileImage;
 }

--- a/src/main/java/com/example/demo/scene/repository/SceneMapper.java
+++ b/src/main/java/com/example/demo/scene/repository/SceneMapper.java
@@ -7,15 +7,19 @@ import org.apache.ibatis.annotations.*;
 public interface SceneMapper {
     // Scene 조회 - scene_id 기준
     @Select("""
-        SELECT s.scene_id, s.social_id, s.theme, s.is_message_visible
+        SELECT s.scene_id, s.social_id, s.theme, s.is_message_visible,
+               u.name AS user_name, u.profile_image_url
         FROM scene s
+        LEFT JOIN user u ON s.social_id = u.social_id
         WHERE s.scene_id = #{sceneId}
-    """)
+""")
     @Results({
             @Result(property = "sceneId", column = "scene_id"),
-            @Result(property = "user.socialId", column = "social_id"),
             @Result(property = "theme", column = "theme"),
             @Result(property = "isMessageVisible", column = "is_message_visible"),
+            @Result(property = "user.socialId", column = "social_id"),
+            @Result(property = "user.name", column = "user_name"),
+            @Result(property = "user.profileImageUrl", column = "profile_image_url"),
     })
     Scene findBySceneId(Long sceneId);
 
@@ -40,15 +44,20 @@ public interface SceneMapper {
 
     // Scene 조회 - socialId 기반으로 Scene 찾기
     @Select("""
-        SELECT s.scene_id, s.social_id, s.theme, s.is_message_visible
+        SELECT s.scene_id, s.social_id, s.theme, s.is_message_visible,
+               u.name AS user_name, u.profile_image_url
         FROM scene s
+        LEFT JOIN user u ON s.social_id = u.social_id
         WHERE s.social_id = #{socialId}
     """)
     @Results({
             @Result(property = "sceneId", column = "scene_id"),
-            @Result(property = "user.socialId", column = "social_id"),
             @Result(property = "theme", column = "theme"),
             @Result(property = "isMessageVisible", column = "is_message_visible"),
+            @Result(property = "user.socialId", column = "social_id"),
+            @Result(property = "user.name", column = "user_name"),
+            @Result(property = "user.profileImageUrl", column = "profile_image_url"),
     })
     Scene findBySocialId(String socialId);
+
 }

--- a/src/main/java/com/example/demo/scene/service/SceneService.java
+++ b/src/main/java/com/example/demo/scene/service/SceneService.java
@@ -211,6 +211,8 @@ public class SceneService {
                 .theme(scene.getTheme())
                 .isMessageVisible(scene.isMessageVisible())
                 .ownerSocialId(scene.getUser() != null ? scene.getUser().getSocialId() : null)
+                .ownerNickname(scene.getUser() != null ? scene.getUser().getName() : null)
+                .ownerProfileImage(scene.getUser() != null ? scene.getUser().getProfileImageUrl() : null)
                 .build();
     }
 

--- a/src/main/java/com/example/demo/user/domain/User.java
+++ b/src/main/java/com/example/demo/user/domain/User.java
@@ -11,10 +11,12 @@ import lombok.Setter;
 public class User {
     private String socialId;
     private String name;
+    private String profileImageUrl;
 
     @Builder
-    public User(String socialId, String name) {
+    public User(String socialId, String name,  String profileImageUrl) {
         this.socialId = socialId;
         this.name = name;
+        this.profileImageUrl = profileImageUrl;
     }
 }

--- a/src/main/java/com/example/demo/user/repository/UserMapper.java
+++ b/src/main/java/com/example/demo/user/repository/UserMapper.java
@@ -8,6 +8,6 @@ public interface UserMapper {
     @Select("SELECT * FROM user WHERE social_id = #{socialId}")
     User findBySocialId(String socialId);
 
-    @Insert("INSERT INTO user (social_id, name) VALUES (#{socialId}, #{name})")
+    @Insert("INSERT INTO user (social_id, name, profile_image_url) VALUES (#{socialId}, #{name}, #{profileImageUrl})")
     void saveUser(User user);
 }

--- a/src/main/java/com/example/demo/user/service/UserService.java
+++ b/src/main/java/com/example/demo/user/service/UserService.java
@@ -34,6 +34,7 @@ public class UserService {
             User newUser = User.builder()
                     .socialId(socialId)
                     .name(nickname)
+                    .profileImageUrl(profileImageUrl)
                     .build();
             userMapper.saveUser(newUser);
             isNewUser = true;


### PR DESCRIPTION
## 유형
- 버그 수정

## 설명
- encryptedSceneId로 scene정보를 조회 시, owner의 정보 중 nickName과 profileImgUrl도 추가 제공해 
- UI구성을 가능하게 합니다

## 테스트
1. kakao url로 로그인
2. accessToken으로 scene 생성, 암호화된 sceneID받기
3. sceneId로 scene정보 조회 시, profileImg와 nickname이 추가 조회 된다
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/6321fea6-bf6e-45a8-8da5-127c17905bfa" />

## 이슈
closes #49 
