### PR TITLE
[FIX] 메세지 작성시 엑세스 인증 로직 제거

### DIFF
--- a/src/main/java/com/example/demo/message/controller/MessageController.java
+++ b/src/main/java/com/example/demo/message/controller/MessageController.java
@@ -42,12 +42,7 @@ public class MessageController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류",
                     content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    public ResponseEntity<ApiResponse<Void>> saveMessage(
-            @CookieValue(name = "access-token", required = false) String accessToken,
-            @RequestBody MessageRequest request) {
-        if (accessToken == null) {
-            return ResponseEntity.status(401).body(ApiResponse.error("인증 실패"));
-        }
+    public ResponseEntity<ApiResponse<Void>> saveMessage(@RequestBody MessageRequest request) {
         messageService.createMessage(request);
         return ResponseEntity.ok(ApiResponse.success(null));
     }


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
누구나 메세지 작성 가능하도록 엑세스 토큰 인증 로직 제거



## 이슈
<!-- 관련 이슈 번호 (PR 병합 시 자동으로 이슈가 닫히도록 'closes #이슈번호' 형식 사용) -->
closes #53
